### PR TITLE
Fix positive density bonus and add to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ Example: java -jar VeinEstimator.jar 1 1 0.4 3 -0.2 10 10 10 80 1000 1 16
 | minY          | integer | minimum y ores can spawn |
 | maxY          | integer | maximum y ores can spawn
 | drawImage     | boolean | whether or not the program should visualize the vein in an image (default true, not required)|
+
+Color shading added by Programmerdan June 2018: 
+The more "green" the greater the peak density in that area. The more
+blue, the closer to the yMin of the vein's "center" is at that x,z --
+the more purple, the closer to the yMax of the vein's "center".
+Basically, the closer you are to yMin/yMax, the stronger you will
+observe the greeness while mining.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Example: java -jar VeinEstimator.jar 1 1 0.4 3 -0.2 10 10 10 80 1000 1 16
 | density       | double | density of ore, should be between 0 and 1                                                                                         |
 | maxSpan       | double | max thickness of the vein                                                                                                         |
 | densityBonus  | double | between -1 and 1, smaller number creates gaps between veins large number makes them more connected. 0 looks kind of like mc caves |
-| areaHeight    | double | average height veins spawn at                                                                                                     |
+| areaHeight    | double | average y-level veins spawn at                                                                                                     |
 | areaSpan      | double | max random difference from the average                                                                                            |
 | heightLength  | double | distance between height slope change                                                                                              |
 | densityLength | double | distance between density slope change (large number = wide vein, small number = compact vein)   |

--- a/com/biggestnerd/veinestimator/VeinEstimator.java
+++ b/com/biggestnerd/veinestimator/VeinEstimator.java
@@ -95,7 +95,7 @@ public class VeinEstimator {
 	
 	private Color heat(double pChance, double vH) {
 		float rvalue = (float) ((vH - (double) minY) /((double) maxY - (double)minY));
-		float gbvalue = (float) Math.min(1.0, (pChance / density)- densityBonus);
+		float gbvalue = (float) Math.max(0.0, Math.min(1.0, (pChance / density)- densityBonus));
 		int r = (int) Math.max(0, Math.min(255, (255 * rvalue)));
 		int g = (int) (255 * gbvalue);
 		int b = (int) (255 * (1.0 - gbvalue));


### PR DESCRIPTION
Fix confusing wording of the areaHeight, add note to readme about the color-coding y levels, fix an error that was thrown anytime you tried to use a positive densityBonus. 